### PR TITLE
Fix claude-bridge tool parameter handling in v1.0.14

### DIFF
--- a/apps/claude-bridge/package.json
+++ b/apps/claude-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mariozechner/claude-bridge",
-	"version": "1.0.13",
+	"version": "1.0.14",
 	"description": "Use non-Anthropic models with Claude Code by proxying requests through the lemmy unified interface",
 	"type": "module",
 	"main": "dist/index.js",

--- a/apps/claude-bridge/src/transforms/lemmy-to-anthropic.ts
+++ b/apps/claude-bridge/src/transforms/lemmy-to-anthropic.ts
@@ -84,7 +84,7 @@ export function createAnthropicSSE(askResult: AskResult, model: string): Readabl
 					writeEvent("content_block_start", {
 						type: "content_block_start",
 						index: blockIndex,
-						content_block: { type: "tool_use", id: toolCall.id, name: toolCall.name, input: {} },
+						content_block: { type: "tool_use", id: toolCall.id, name: toolCall.name, input: toolCall.arguments },
 					});
 					const argsJson = JSON.stringify(toolCall.arguments);
 					for (let i = 0; i < argsJson.length; i += 50) {


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in claude-bridge where tool parameters were being lost during the lemmy-to-anthropic transformation, causing tool calls to fail with 'required parameter is missing' errors.

## Changes Made

### Bug Fix
- **Fixed tool parameter handling**: In , the  field now correctly uses  instead of an empty object 
- This resolves issues where tools like the Write tool were missing the  parameter

### Version Bump
- Updated package version from  to 
- Rebuilt the package to include the fix in the distributed files

## Impact
- ✅ Tool calls now properly pass all required parameters
- ✅ Write tool and other tools work correctly through claude-bridge
- ✅ No breaking changes - this is a patch release

## Testing
- Verified the fix is compiled into the distribution files
- Confirmed tool parameters are now properly included in the transformation

This fix ensures that claude-bridge properly handles tool calls when proxying requests from Claude Code to other LLM providers.